### PR TITLE
Ensure that the same XML parser security features are used when XSD validation is on and off

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/services/ValidatingXmlLoader.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/services/ValidatingXmlLoader.scala
@@ -34,10 +34,11 @@ class ValidatingXmlLoader extends XMLLoader[Elem]:
     ThreadLocal.withInitial { () =>
       val factory = SAXParserFactory.newInstance()
       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
       factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
       factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+      factory.setFeature("http://xml.org/sax/features/resolve-dtd-uris", false)
       factory.setNamespaceAware(true)
       factory.setXIncludeAware(false)
       factory.setSchema(soapSchema)


### PR DESCRIPTION
This ensures that our custom XMLLoader that does XSD validation uses the same [security features](https://xerces.apache.org/xerces2-j/features.html) as [Scala's built in one](https://github.com/scala/scala-xml/blob/df279b23671f2b673413dfbfcdf1f83eb5301bdd/shared/src/main/scala/scala/xml/factory/XMLLoader.scala#L28), with the exception that namespace processing is enabled for ours.