### PR TITLE
Disable XSD validation by default

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,7 +71,7 @@ mongodb {
 
 microservice {
   features {
-    xsdValidation = true
+    xsdValidation = false
   }
 
   services {


### PR DESCRIPTION
We don't know why this is the case, but the payloads we receive from the EU seem to have XML namespaces that don't match their contents.

In that scenario XSD validation is never going to work, so we will disable it until we understand what's going on.