### PR TITLE
CRDL-226 Enable the service to handle the isAlive message from the CCN

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SoapAction.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SoapAction.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.centralreferencedatainboundorchestrator.models
+
+enum SoapAction(private val action: String) {
+  case ReceiveReferenceData extends SoapAction(SoapAction.ReceiveReferenceDataAction)
+  case IsAlive extends SoapAction(SoapAction.IsAliveAction)
+}
+
+object SoapAction {
+  private lazy val ReceiveReferenceDataAction        =
+    "CCN2.Service.Customs.Default.CSRD.ReferenceDataExportReceiverCBS/ReceiveReferenceData"
+  private lazy val IsAliveAction                     = "CCN2.Service.Customs.Default.CSRD.ReferenceDataExportReceiverCBS/IsAlive"
+  def fromString(action: String): Option[SoapAction] =
+    SoapAction.values.find(_.action == action)
+}

--- a/conf/schemas/isalive-message.xsd
+++ b/conf/schemas/isalive-message.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+This is a simplified version of the V1 Monitoring.xsd from the CSRD2 Service Specifications
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://xmlns.ec.eu/BusinessMessages/TATAFng/Monitoring/V1"
+           targetNamespace="http://xmlns.ec.eu/BusinessMessages/TATAFng/Monitoring/V1"
+           elementFormDefault="qualified">
+    <xs:element name="isAliveReqMsg">
+        <xs:complexType>
+            <xs:sequence />
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/conf/schemas/soap-envelope.xsd
+++ b/conf/schemas/soap-envelope.xsd
@@ -6,11 +6,14 @@ The change made was to require that the content of the SOAP body conforms to the
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.w3.org/2003/05/soap-envelope"
            xmlns:reqmsg="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataExportReceiverCBS/V4"
+           xmlns:alivemsg="http://xmlns.ec.eu/BusinessMessages/TATAFng/Monitoring/V1"
            targetNamespace="http://www.w3.org/2003/05/soap-envelope" elementFormDefault="qualified">
 
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
 
     <xs:import namespace="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataExportReceiverCBS/V4" schemaLocation="request-message.xsd"/>
+
+    <xs:import namespace="http://xmlns.ec.eu/BusinessMessages/TATAFng/Monitoring/V1" schemaLocation="isalive-message.xsd"/>
 
     <!-- Envelope, header and body -->
     <xs:element name="Envelope" type="tns:Envelope"/>
@@ -39,7 +42,10 @@ The change made was to require that the content of the SOAP body conforms to the
     <xs:complexType name="Body">
         <xs:sequence>
             <!-- NOTE: This change to the original SOAP Envelope schema applies the validation of the CS/RD2 request message -->
-            <xs:element ref="reqmsg:ReceiveReferenceDataReqMsg" />
+            <xs:choice>
+                <xs:element ref="reqmsg:ReceiveReferenceDataReqMsg" />
+                <xs:element ref="alivemsg:isAliveReqMsg" />
+            </xs:choice>
         </xs:sequence>
         <xs:anyAttribute namespace="##other" processContents="lax"/>
     </xs:complexType>

--- a/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerISpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock.*
-import helpers.InboundSoapMessage
 import org.mongodb.scala.SingleObservableFuture
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
@@ -29,6 +28,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.DefaultBodyWritables.*
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers.*
+import uk.gov.hmrc.centralreferencedatainboundorchestrator.helpers.InboundSoapMessage
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.repositories.MessageWrapperRepository
 import uk.gov.hmrc.http.test.ExternalWireMockSupport
 import uk.gov.hmrc.mongo.test.MongoSupport

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,7 @@ object AppDependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"             % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"            % hmrcMongoVersion
-  ).map(_ % "test")
+  ).map(_ % Test)
 
   val it: Seq[ModuleID] = Seq.empty
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables" % "2.6.0")
 addSbtPlugin("org.playframework"  % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "2.3.0")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % "2.5.4")
+
+addDependencyTreePlugin

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/helpers/InboundSoapMessage.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/helpers/InboundSoapMessage.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package helpers
+package uk.gov.hmrc.centralreferencedatainboundorchestrator.helpers
 
 import scala.xml.Elem
 
 object InboundSoapMessage {
-
 
   val valid_soap_message: Elem =
     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
@@ -44,9 +43,9 @@ object InboundSoapMessage {
         </v4:ReceiveReferenceDataReqMsg>
       </soap:Body>
     </soap:Envelope>
-    
+
   val valid_soap_error_report_message: Elem =
-      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
+    <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
                      xmlns:v4="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataExportReceiverCBS/V4"
                      xmlns:v41="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataExportReceiverCBSServiceType/V4"
                      xmlns:v2="http://xmlns.ec.eu/BusinessObjects/CSRD2/MessageHeaderType/V2">


### PR DESCRIPTION
As part of the prod implementation the EU triggered an isAlive message.

We were not aware that we were supposed to handle that message within this service, and neither apparently were the previous team.

This PR reworks the service to handle that message type, extending the XSD validation to account for that namespace and message structure.

At the moment the service simply replies with an empty body and a 200 OK status code, but if that causes problems we could alter the service to produce a full acknowledgement message.