### PR TITLE
Move TestController into testonly package to avert PR bot warning

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/testonly/TestController.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/testonly/TestController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers
+package uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.testonly
 
 import play.api.mvc.*
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.repositories.{EISWorkItemRepository, MessageWrapperRepository}

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,8 +11,8 @@
 
 # Add all the application routes to the prod.routes file
 # Test only routes
-DELETE  /test-only/message-wrappers             uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.TestController.clearAllWrappers()
-DELETE  /test-only/eis-work-items               uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.TestController.clearAllWorkItems()
-GET     /test-only/message-wrappers/:id         uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.TestController.findById(id)
+DELETE  /test-only/message-wrappers             uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.testonly.TestController.clearAllWrappers()
+DELETE  /test-only/eis-work-items               uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.testonly.TestController.clearAllWorkItems()
+GET     /test-only/message-wrappers/:id         uk.gov.hmrc.centralreferencedatainboundorchestrator.controllers.testonly.TestController.findById(id)
 
 ->         /                          prod.Routes

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,21 +1,21 @@
 import play.core.PlayVersion
-import play.sbt.PlayImport._
+import play.sbt.PlayImport.*
 import sbt.Keys.libraryDependencies
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
   private val bootstrapVersion = "9.11.0"
-  private val hmrcMongoVersion = "2.5.0"
+  private val hmrcMongoVersion = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-30"          % bootstrapVersion,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-work-item-repo-play-30"  % hmrcMongoVersion
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-30"         % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-work-item-repo-play-30" % hmrcMongoVersion
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"             % bootstrapVersion,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"            % hmrcMongoVersion
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30"  % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % hmrcMongoVersion
   ).map(_ % Test)
 
   val it: Seq[ModuleID] = Seq.empty

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.10.10


### PR DESCRIPTION
The warning was caused by the TestController sharing the same Java package as the other controllers in the project.