### PR TITLE
CRDL-242 Only action notifications when we are in the expected status for that notification

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundController.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundController.scala
@@ -77,9 +77,9 @@ class InboundController @Inject() (
         Success(Accepted)
       case Failure(err: Throwable) =>
         err match {
-          case InvalidXMLContentError(_)              => Success(BadRequest)
-          case MongoReadError(_) | MongoWriteError(_) => Success(InternalServerError)
-          case _                                      => Success(InternalServerError)
+          case InvalidXMLContentError(_)                    => Success(BadRequest)
+          case MongoReadError(_, _) | MongoWriteError(_, _) => Success(InternalServerError)
+          case _                                            => Success(InternalServerError)
         }
     }
 

--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/SdesCallbackController.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/SdesCallbackController.scala
@@ -37,9 +37,9 @@ class SdesCallbackController @Inject() (sdesService: SdesService, cc: Controller
       case Success(_)              => Success(Accepted)
       case Failure(err: Throwable) =>
         err match
-          case NoMatchingUIDInMongoError(_)           => Success(NotFound)
-          case InvalidSDESNotificationError(_)        => Success(BadRequest)
-          case MongoReadError(_) | MongoWriteError(_) => Success(InternalServerError)
-          case _                                      => Success(InternalServerError)
+          case NoMatchingUIDInMongoError(_)                 => Success(NotFound)
+          case InvalidSDESNotificationError(_)              => Success(BadRequest)
+          case MongoReadError(_, _) | MongoWriteError(_, _) => Success(InternalServerError)
+          case _                                            => Success(InternalServerError)
     }
   }

--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/CRDLErrors.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/CRDLErrors.scala
@@ -16,17 +16,16 @@
 
 package uk.gov.hmrc.centralreferencedatainboundorchestrator.models
 
-abstract class CRDLErrors(message: String) extends Throwable(message)
-case class InvalidXMLContentError(message: String) extends CRDLErrors(message)
+abstract class CRDLErrors(message: String, cause: Throwable) extends Throwable(message, cause)
 
-case class MongoWriteError(message: String) extends CRDLErrors(message)
+case class InvalidXMLContentError(message: String) extends CRDLErrors(message, null)
 
-case class MongoReadError(message: String) extends CRDLErrors(message)
+case class MongoWriteError(message: String, cause: Throwable = null) extends CRDLErrors(message, cause)
 
-case class EisResponseError(message: String) extends CRDLErrors(message)
+case class MongoReadError(message: String, cause: Throwable = null) extends CRDLErrors(message, cause)
 
-case class AVScanFailureError(message: String) extends CRDLErrors(message)
+case class EisResponseError(message: String) extends CRDLErrors(message, null)
 
-case class NoMatchingUIDInMongoError(message: String) extends CRDLErrors(message)
+case class NoMatchingUIDInMongoError(message: String) extends CRDLErrors(message, null)
 
-case class InvalidSDESNotificationError(message: String) extends CRDLErrors(message)
+case class InvalidSDESNotificationError(message: String) extends CRDLErrors(message, null)

--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/MessageStatus.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/MessageStatus.scala
@@ -21,9 +21,17 @@ import play.api.libs.json.*
 object MessageStatus extends Enumeration:
   type MessageStatus = Value
 
+  // Received the message wrapper from the public SOAP proxy
   val Received: Value = Value("Received")
-  val Sent: Value     = Value("Sent")
-  val Pass: Value     = Value("ScanPassed")
-  val Fail: Value     = Value("ScanFailed")
+
+  // Received an AV scanning notification from SDES
+  val Pass: Value = Value("ScanPassed")
+  val Fail: Value = Value("ScanFailed")
+
+  // Submitted the item to the work queue for sending to EIS
+  val Submitted: Value = Value("Submitted")
+
+  // Sent the message wrapper on to DPS via EIS
+  val Sent: Value = Value("Sent")
 
   given format: Format[MessageStatus] = Json.formatEnum(this)

--- a/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/repositories/MessageWrapperRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/repositories/MessageWrapperRepositoryISpec.scala
@@ -76,7 +76,7 @@ class MessageWrapperRepositoryISpec
       val fetchedRecord = messageRepository.findByUid(messageWrapper.uid).futureValue
 
       insertResult mustEqual true
-      fetchedRecord.value.copy(lastUpdated = instant, receivedTimestamp = instant) mustEqual messageWrapper
+      fetchedRecord.value mustEqual messageWrapper
     }
 
     "must return none if uid not found" in {
@@ -98,6 +98,15 @@ class MessageWrapperRepositoryISpec
 
       insertResult mustEqual true
       fetchedRecord.value mustEqual messageWrapper.copy(status = Pass)
+    }
+
+    "must return none if the message wrapper is not at the expected status" in {
+
+      val insertResult = messageRepository.insertMessageWrapper(messageWrapper.uid, messageWrapper.payload, Fail).futureValue
+      val fetchedRecord = messageRepository.findByUidAndUpdateStatus(messageWrapper.uid, expectedStatus = Received, newStatus = Pass).futureValue
+
+      insertResult mustEqual true
+      fetchedRecord must be(None)
     }
 
     "must return none if uid not found" in {

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/helpers/InboundSoapMessage.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/helpers/InboundSoapMessage.scala
@@ -20,7 +20,7 @@ import scala.xml.Elem
 
 object InboundSoapMessage {
 
-  val valid_soap_message: Elem =
+  def valid_soap_message_with_id(uid: String): Elem =
     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
                    xmlns:v4="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataExportReceiverCBS/V4"
                    xmlns:v41="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataExportReceiverCBSServiceType/V4"
@@ -39,10 +39,12 @@ object InboundSoapMessage {
             <v2:timeCreation>2023-10-03T16:00:00</v2:timeCreation>
           </v41:MessageHeader>
           <v41:TaskIdentifier>TASKID12345</v41:TaskIdentifier>
-          <v41:ReceiveReferenceDataRequestResult>c04a1612-705d-4373-8840-9d137b14b301</v41:ReceiveReferenceDataRequestResult>
+          <v41:ReceiveReferenceDataRequestResult>{uid}</v41:ReceiveReferenceDataRequestResult>
         </v4:ReceiveReferenceDataReqMsg>
       </soap:Body>
     </soap:Envelope>
+
+  val valid_soap_message: Elem = valid_soap_message_with_id("c04a1612-705d-4373-8840-9d137b14b301")
 
   val valid_soap_is_alive_message: Elem =
     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/repositories/MessageWrapperRepositorySpec.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/repositories/MessageWrapperRepositorySpec.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.centralreferencedatainboundorchestrator.config.AppConfig
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.models.MessageStatus.Received
 import uk.gov.hmrc.mongo.test.CleanMongoCollectionSupport
 
+import java.time.Clock
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -35,7 +36,7 @@ class MessageWrapperRepositorySpec
       Matchers:
 
   val appConfig: AppConfig                 = mock[AppConfig]
-  val repository: MessageWrapperRepository = MessageWrapperRepository(mongoComponent, appConfig)
+  val repository: MessageWrapperRepository = MessageWrapperRepository(mongoComponent, appConfig, Clock.systemUTC())
 
   "MessageWrapperRepository" should {
     "Delete all existing documents" in {


### PR DESCRIPTION
This is a speculative change that would prevent us from processing notifications twice in the event that we receive duplicate notifications from SDES.

This is achieved by using a "compare-and-set" methodology for updating message wrapper statuses.

We only update a message if it's already in the expected status for the current notification.

This logic forms a state machine, so that we can only transition between statuses in the following ways:
```
Received -> Pass
Received -> Fail

Pass -> Submitted

Submitted -> Sent
```