### PR TITLE
Up max memory buffer to be able to ingest large TAXUD messages

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -43,6 +43,10 @@ play.i18n.langs = ["en"]
 # !!!WARNING!!! DO NOT CHANGE THIS ROUTER
 play.http.router = prod.Routes
 
+# Max Memory
+# ~~~~~
+play.http.parser.maxMemoryBuffer = 5M
+
 # Controller
 # ~~~~~
 # By default all controllers will have authorisation, logging and


### PR DESCRIPTION
We are seeing "test" messages come in on QA at approx 1.5MB which exceeds the default memory buffer settings.
As such, we need increase it in order for the incoming messages to be ingested successfully.