### PR TITLE
CRDL-557: Update return for SubscriptionChange

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundController.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundController.scala
@@ -100,7 +100,7 @@ class InboundController @Inject() (
           case Some(uuid) =>
             workItemRepo
               .set(EISRequest(validatedMessage.toString, uuid, SoapAction.ReferenceDataSubscription))
-              .map(_ => Accepted(s"Message with UID: $uuid, successfully queued"))
+              .map(_ => Ok(SubscriptionChangeResponse.acknowledgement(uuid)))
           case None       =>
             val rawMessageId =
               (validatedMessage \\ "Header" \ "MessageID").headOption.map(_.text.trim).getOrElse("not present")

--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponse.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponse.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.centralreferencedatainboundorchestrator.models
+
+object SubscriptionChangeResponse {
+  val acknowledgement = (messageId: String) =>
+    <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+       <soap:Body>
+            <ns15:ReceiveReferenceDataRespMsg xmlns:ns0="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataSubscriptionReceiverCBSServiceType/V4"
+            xmlns:ns15="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataSubscriptionReceiverCBS/V4"
+            xmlns:ns3="http://xmlns.ec.eu/BusinessObjects/CSRD2/CommonServiceType/V3"
+            xmlns:ns5="http://xmlns.ec.eu/BusinessObjects/CSRD2/MessageHeaderType/V2">
+                <ns3:MessageHeader>
+                    <ns5:AddressingInformation>
+                        <ns5:messageID>{messageId}</ns5:messageID>
+                    </ns5:AddressingInformation>
+                </ns3:MessageHeader>
+                <ns3:acknowledgement>OK</ns3:acknowledgement>
+            </ns15:ReceiveReferenceDataRespMsg>
+        </soap:Body>
+    </soap:Envelope>
+}

--- a/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponse.scala
+++ b/app/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponse.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.centralreferencedatainboundorchestrator.models
 
 object SubscriptionChangeResponse {
-  val acknowledgement = (messageId: String) =>
-    <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+  val acknowledgement = (messageId: String) => <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
        <soap:Body>
             <ns15:ReceiveReferenceDataRespMsg xmlns:ns0="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataSubscriptionReceiverCBSServiceType/V4"
             xmlns:ns15="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataSubscriptionReceiverCBS/V4"

--- a/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerISpec.scala
@@ -33,12 +33,14 @@ import uk.gov.hmrc.centralreferencedatainboundorchestrator.helpers.{InboundSoapM
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.models.MessageStatus
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.models.MessageStatus.MessageStatus
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.models.SoapAction.ReferenceDataSubscription
+import uk.gov.hmrc.centralreferencedatainboundorchestrator.models.SubscriptionChangeResponse
 import uk.gov.hmrc.centralreferencedatainboundorchestrator.repositories.{EISWorkItemRepository, MessageWrapperRepository}
 import uk.gov.hmrc.http.test.ExternalWireMockSupport
 import uk.gov.hmrc.mongo.test.MongoSupport
 import uk.gov.hmrc.mongo.workitem.ProcessingStatus
 
 import scala.xml.Elem
+import scala.xml.Utility.trim
 
 class InboundControllerISpec extends AnyWordSpec,
   Matchers,
@@ -376,9 +378,8 @@ class InboundControllerISpec extends AnyWordSpec,
           .post(subscriptionMessageWithRDEntityList)
           .futureValue
 
-      response.status shouldBe ACCEPTED
-      response.body.toString should include("12345678-1234-1234-1234-123456789012")
-      response.body.toString should include("successfully queued")
+      response.status shouldBe OK
+      trim(response.body) shouldBe trim(SubscriptionChangeResponse.acknowledgement("12345678-1234-1234-1234-123456789012"))
       
       val workItems = await(workItemRepository.collection.find().toFuture())
       workItems.size shouldBe 1

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerSpec.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/controllers/InboundControllerSpec.scala
@@ -227,9 +227,10 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, BeforeAndA
           .withBody(subscriptionMessageWithRDEntityList.toString)
       )
 
-      status(result)        shouldBe ACCEPTED
-      contentAsString(result) should include("12345678-1234-1234-1234-123456789abc")
-      contentAsString(result) should include("successfully queued")
+      status(result)        shouldBe OK
+      contentAsString(result) should be(
+        SubscriptionChangeResponse.acknowledgement("12345678-1234-1234-1234-123456789abc").toString()
+      )
 
       verify(mockAuditHandler, times(1)).auditNewMessageWrapper(any)(any)
       verify(mockValidationService, times(1)).validateAndExtractAction(any)

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponseSpec.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponseSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.centralreferencedatainboundorchestrator.models
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import scala.xml.Utility.trim
+
+class SubscriptionChangeResponseSpec extends AnyWordSpec, Matchers {
+  "acknowledgement" should {
+    val testMessageId = "6AFB3F32-9DD8-44C6-A8A0-0D04AB175F0E"
+    val expectedAcknowledgement = 
+        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+            <soap:Body>
+                <ns15:ReceiveReferenceDataRespMsg xmlns:ns0="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataSubscriptionReceiverCBSServiceType/V4"
+                xmlns:ns15="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataSubscriptionReceiverCBS/V4"
+                xmlns:ns3="http://xmlns.ec.eu/BusinessObjects/CSRD2/CommonServiceType/V3"
+                xmlns:ns5="http://xmlns.ec.eu/BusinessObjects/CSRD2/MessageHeaderType/V2">
+                    <ns3:MessageHeader>
+                        <ns5:AddressingInformation>
+                            <ns5:messageID>6AFB3F32-9DD8-44C6-A8A0-0D04AB175F0E</ns5:messageID>
+                        </ns5:AddressingInformation>
+                    </ns3:MessageHeader>
+                    <ns3:acknowledgement>OK</ns3:acknowledgement>
+                </ns15:ReceiveReferenceDataRespMsg>
+            </soap:Body>
+        </soap:Envelope>
+    "return a valid message" in {
+        val result = SubscriptionChangeResponse.acknowledgement(testMessageId)
+        trim(result) shouldEqual trim(expectedAcknowledgement)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponseSpec.scala
+++ b/test/uk/gov/hmrc/centralreferencedatainboundorchestrator/models/SubscriptionChangeResponseSpec.scala
@@ -22,9 +22,9 @@ import scala.xml.Utility.trim
 
 class SubscriptionChangeResponseSpec extends AnyWordSpec, Matchers {
   "acknowledgement" should {
-    val testMessageId = "6AFB3F32-9DD8-44C6-A8A0-0D04AB175F0E"
-    val expectedAcknowledgement = 
-        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+    val testMessageId           = "6AFB3F32-9DD8-44C6-A8A0-0D04AB175F0E"
+    val expectedAcknowledgement =
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
             <soap:Body>
                 <ns15:ReceiveReferenceDataRespMsg xmlns:ns0="http://xmlns.ec.eu/BusinessObjects/CSRD2/ReferenceDataSubscriptionReceiverCBSServiceType/V4"
                 xmlns:ns15="http://xmlns.ec.eu/CallbackService/CSRD2/IReferenceDataSubscriptionReceiverCBS/V4"
@@ -40,8 +40,8 @@ class SubscriptionChangeResponseSpec extends AnyWordSpec, Matchers {
             </soap:Body>
         </soap:Envelope>
     "return a valid message" in {
-        val result = SubscriptionChangeResponse.acknowledgement(testMessageId)
-        trim(result) shouldEqual trim(expectedAcknowledgement)
+      val result = SubscriptionChangeResponse.acknowledgement(testMessageId)
+      trim(result) shouldEqual trim(expectedAcknowledgement)
     }
   }
 }


### PR DESCRIPTION
[[CRDL-557]](https://jira.tools.tax.service.gov.uk/browse/CRDL-557)

Update response the SubscriptionChange message to match spec for ReceiveReferenceDataResponseType.

See ticket for details, this should meet the spec that the EU have informed us they required at CCN/2 in order to mark the request they sent to us as successful.
In short, a 200 response with a ReceiveReferenceDataRespMsg body.